### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,17 +22,17 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.8.1
+    rev: v3.8.2
     hooks:
       - id: reorder-python-imports
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.0
     hooks:
       - id: prettier
         stages: [commit]


### PR DESCRIPTION
* github.com/pycqa/flake8: 4.0.1 -> 5.0.4
* github.com/asottile/reorder_python_imports: v3.8.1 -> v3.8.2
* github.com/pre-commit/mirrors-prettier: v2.7.1 -> v3.0.0-alpha.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
