### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --branch=main
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
 
@@ -43,7 +43,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.27.1
+    rev: v1.28.0
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
* github.com/psf/black: 22.6.0 -> 22.8.0
* github.com/adrienverge/yamllint: v1.27.1 -> v1.28.0

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
