### PR TITLE
Fix: Only fire waste can notify on day before

### DIFF
--- a/waste-can-notices.yaml
+++ b/waste-can-notices.yaml
@@ -137,7 +137,7 @@ variables:
   # yamllint disable-line rule:line-length
   notify_target: "{{ input_notify_service | lower | replace('notify.', '') | replace(' ', '_') }}"
   do_notify: >-
-    {%- if input_garbage_sensor < 2 and input_recycling_sensor < 2 -%}
+    {%- if input_garbage_sensor == 1 and input_recycling_sensor == 1 -%}
       true
     {%- else -%}
       false


### PR DESCRIPTION
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
