### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: 98f2281f56be5503f3851e74556e1122fc18b2a8 # frozen: v1.31.0
+    rev: b05e028c5881819161d11cb543fd96a30c06cceb # frozen: v1.32.0
     hooks:
       - id: yamllint
 


### PR DESCRIPTION
github.com/adrienverge/yamllint: v1.31.0 (frozen) -> v1.32.0 (frozen)

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
