### PR TITLE
Fix: Use 'type' instead of 'mode' for text input

### DIFF
--- a/guest-entry-notifier.yaml
+++ b/guest-entry-notifier.yaml
@@ -63,7 +63,7 @@ blueprint:
       selector:
         text:
           multiline: false
-          mode: text
+          type: text
       default: ""
     separate_topics:
       name: Separate Topics


### PR DESCRIPTION
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
