### PR TITLE
Feat: Allow 250 slots on locks

### DIFF
--- a/guest-entry-notifier.yaml
+++ b/guest-entry-notifier.yaml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 blueprint:
-  name: Guest Entry Notifier (v0.4)
+  name: Guest Entry Notifier (v0.5)
 
   description: |
     Basic thread starter for use with Rental Control and Zulip
@@ -53,7 +53,7 @@ blueprint:
       selector:
         number:
           min: 1
-          max: 30
+          max: 250
       default: 10
     topic:
       name: Zulip Topic


### PR DESCRIPTION
When this blueprint was first created the maximum number of slots on any
of the locks avaiable was 30. Since then, a new lock with 250 slots has
started to be used and we need to allow for that.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
