### PR TITLE
Fix: Change logic for multiple days

### DIFF
--- a/low-battery.yaml
+++ b/low-battery.yaml
@@ -4,7 +4,7 @@
 # Original code from:
 # https://gist.github.com/sbyx/1f6f434f0903b872b84c4302637d0890
 blueprint:
-  name: Low battery level detection & notification for all battery sensors
+  name: Low battery level notification for all battery sensors (v1.3)
   description: v1.2 Regularly test all sensors with 'battery' device-class for
     crossing a certain battery level threshold and if so execute an action.
   domain: automation
@@ -27,18 +27,32 @@ blueprint:
       default: "10:00:00"
       selector:
         time: {}
-    day:
-      name: Weekday to test on
+    days:
+      name: (Required) Days to run test
       description: >
-        Test is run at configured time either everyday (0) or on a
-        given weekday (1: Monday ... 7: Sunday)
-      default: 0
+        Days of the week when the automation is active.
       selector:
-        number:
-          min: 0.0
-          max: 7.0
-          mode: slider
-          step: 1.0
+        select:
+          options:
+            - Monday
+            - Tuesday
+            - Wednesday
+            - Thursday
+            - Friday
+            - Saturday
+            - Sunday
+          mode: list
+          multiple: true
+          sort: false
+          custom_value: true
+          default:
+            - Monday
+            - Tuesday
+            - Wednesday
+            - Thursday
+            - Friday
+            - Saturday
+            - Sunday
     exclude:
       name: Excluded Sensors
       description: Battery sensors (e.g. smartphone) to exclude from detection.
@@ -81,7 +95,7 @@ trigger:
   - platform: time
     at: !input "time"
 condition:
-  - "{{ sensors != '' and (day | int == 0 or day | int == now().isoweekday()) }}"
+  - "{{ sensors != '' and now().strftime('%A') in days }}"
 action:
   - choose: []
     default: !input "actions"


### PR DESCRIPTION
HA 2025.5.3 looks to have broken some of the logic related to if the
notification should happen. Change it to allow for multiple days and use
a different condition to check if the current day is in the list of
days.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
