### PR TITLE
Fix: Update to support Keymaster >= 0.1.0-b0

### DIFF
--- a/guest-entry-notifier.yaml
+++ b/guest-entry-notifier.yaml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 blueprint:
-  name: Guest Entry Notifier (v0.6.1)
+  name: Guest Entry Notifier (v0.7.0)
 
   description: |
     Basic thread starter for use with Rental Control and Zulip
@@ -83,7 +83,7 @@ trigger:
         {%- else -%}
           {{ trigger.event.data.code_slot_name }}
         {%- endif -%}
-      slot_num: "{{ trigger.event.data.code_slot }}"
+      slot_num: "{{ trigger.event.data.code_slot_num }}"
       lock: "{{ trigger.event.data.entity_id }}"
   - platform: calendar
     event: end


### PR DESCRIPTION
This no longer supports Keymaster < 0.1.0-b0, as the data structure
has changed to use `code_slot_num` instead of `code_slot`.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
