### PR TITLE
Fix(blueprint): Add event sensor triggers for immediate reservation handling

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -84,8 +84,18 @@ triggers:
   - trigger: time_pattern
     hours: !input check_interval
     id: periodic_sync
+  - trigger: event
+    event_type: state_changed
+    id: event_sensor_update
 
-conditions: []
+conditions:
+  - condition: template
+    value_template: >-
+      {{ trigger.id != 'event_sensor_update'
+      or trigger.event.data.entity_id in
+      ['sensor.rental_control_' ~ rc_device
+      ~ '_event_' ~ i
+      for i in range(max_events | int)] }}
 
 actions:
   - repeat:

--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -76,6 +76,10 @@ variables:
 
   # Derived
   rc_device: "{{ device_name(rc) | slugify }}"
+  rc_event_entities: >-
+    {{ ['sensor.rental_control_' ~ rc_device
+    ~ '_event_' ~ i
+    for i in range(max_events | int)] }}
 
 triggers:
   - trigger: state
@@ -84,6 +88,10 @@ triggers:
   - trigger: time_pattern
     hours: !input check_interval
     id: periodic_sync
+  # state_changed fires for every entity; the condition below
+  # filters to our event sensors. HA state triggers do not
+  # support templated entity_id, so this is the recommended
+  # workaround for dynamically derived entity lists.
   - trigger: event
     event_type: state_changed
     id: event_sensor_update
@@ -92,10 +100,8 @@ conditions:
   - condition: template
     value_template: >-
       {{ trigger.id != 'event_sensor_update'
-      or trigger.event.data.entity_id in
-      ['sensor.rental_control_' ~ rc_device
-      ~ '_event_' ~ i
-      for i in range(max_events | int)] }}
+      or trigger.event.data.entity_id
+      in rc_event_entities }}
 
 actions:
   - repeat:


### PR DESCRIPTION
## Summary

Adds a `state_changed` event trigger to the Rental Control Guesty Slot
Code Sync blueprint so the automation fires immediately when event
sensors update (e.g., last-minute reservations with new slot codes).

## Problem

The blueprint only triggered on calendar state changes and a periodic
time pattern. If a reservation arrived between sync intervals, the slot
code wouldn't be pushed to Guesty until the next hourly check.

## Approach

HA state triggers do not support templated `entity_id` fields, so the
standard community workaround is used: a `state_changed` event trigger
paired with a template condition that filters by dynamically built
entity IDs (`sensor.rental_control_{device}_event_{N}`).

The condition short-circuits via Jinja2 `or` — for `calendar_update`
and `periodic_sync` triggers, `trigger.id != 'event_sensor_update'`
evaluates true immediately, so `trigger.event` is never accessed.

## Changes

- Added `trigger: event` / `event_type: state_changed` with ID
  `event_sensor_update`
- Replaced `conditions: []` with a template condition that passes
  calendar/periodic triggers unconditionally and filters event triggers
  against the derived event sensor entity ID list