### PR TITLE
Fix(blueprint): Restore Guesty listing input

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -21,6 +21,16 @@ blueprint:
         entity:
           domain: calendar
           integration: rental_control
+    guesty_listing:
+      name: Guesty Listing
+      description: >-
+        The Guesty listing sensor that corresponds to this
+        rental control calendar. Used to associate this
+        automation with the correct Guesty listing.
+      selector:
+        entity:
+          domain: sensor
+          integration: guesty
     custom_field_id:
       name: Guesty Custom Field ID
       description: |


### PR DESCRIPTION
Add back the `guesty_listing` entity input to the rental-control-guesty-slot-code blueprint. This input lets users associate each automation instance with a specific Guesty listing sensor, which is essential for organizational clarity when managing multiple rental units with separate Rental Control integrations.

The input is placed after `rental_control_calendar` and before `custom_field_id`. It is not referenced in variables or actions because the `set_custom_field` service identifies reservations by `booking_id`, which is globally unique.