### PR TITLE
Fix(blueprint): Use valid Jinja2 for entity list

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -77,9 +77,13 @@ variables:
   # Derived
   rc_device: "{{ device_name(rc) | slugify }}"
   rc_event_entities: >-
-    {{ ['sensor.rental_control_' ~ rc_device
-    ~ '_event_' ~ i
-    for i in range(max_events | int)] }}
+    {%- set ns = namespace(entities=[]) -%}
+    {%- for i in range(max_events | int) -%}
+      {%- set ns.entities = ns.entities +
+      ['sensor.rental_control_' ~ rc_device
+      ~ '_event_' ~ i] -%}
+    {%- endfor -%}
+    {{ ns.entities }}
 
 triggers:
   - trigger: state


### PR DESCRIPTION
## Summary

Replace Python list comprehension syntax in `rc_event_entities` with a
Jinja2 namespace loop. HA's Jinja2 engine does not support list
comprehensions (`[x for x in y]`), which caused a
`TemplateSyntaxError: expected token ',', got 'for'` at runtime.

## What changed

`rental-control-guesty-slot-code.yaml`: The `rc_event_entities`
variable now uses a `namespace` + `for` loop to build the entity list
instead of the invalid Python-style list comprehension.

## Testing

- `yamllint` passes
- Template produces a valid list: `['sensor.rental_control_<device>_event_0', ...]`
- Used correctly in the `in` condition check