### PR TITLE
Fix(blueprint): Force slot_code to string

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -128,7 +128,7 @@ actions:
             - variables:
                 slot_code: >-
                   {{ state_attr(event_entity,
-                  'slot_code') }}
+                  'slot_code') | string }}
                 booking_id_raw: >-
                   {{ state_attr(event_entity,
                   'booking_id') }}
@@ -144,4 +144,4 @@ actions:
                 target_type: reservation
                 target_id: "{{ reservation_id }}"
                 field_id: "{{ custom_field_id }}"
-                value: "{{ slot_code }}"
+                value: "{{ slot_code | string }}"


### PR DESCRIPTION
Jinja2 auto-coerces numeric-looking values to integers, which drops leading zeros (e.g. `0142` becomes `142`). The Guesty API rejects integers and requires a string value.

This PR adds the `| string` filter at both:
1. The `slot_code` variable assignment
2. The `value` field in the service call template

This preserves the original text representation of door codes, including any leading zeros.