### PR TITLE
Fix(blueprint): Use dict pattern for string

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -140,8 +140,10 @@ actions:
                   {%- endif -%}
             - action: guesty.set_custom_field
               metadata: {}
-              data:
-                target_type: reservation
-                target_id: "{{ reservation_id }}"
-                field_id: "{{ custom_field_id }}"
-                value: "{{ slot_code | string }}"
+              data: >-
+                {{ dict(
+                  target_type='reservation',
+                  target_id=reservation_id | string,
+                  field_id=custom_field_id,
+                  value=slot_code | string
+                ) }}


### PR DESCRIPTION
Fixes production error: `Expected str for field type 'text', got int`

The `guesty.set_custom_field` service call was passing `slot_code` as an
integer despite using `| string` in the YAML template. HA renders
`"{{ slot_code | string }}"` to bare `1234`, which is then re-coerced to
int during service call data processing.

This switches to the Jinja `dict()` constructor pattern (already proven
in `rental-control-schlage.yaml`) which preserves Python string types
through HA's template rendering pipeline. Also applies `| string` to
`reservation_id` defensively since booking IDs could look numeric.