### PR TITLE
Feat(blueprint): Add read-before-write check

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -139,6 +139,7 @@ actions:
                   {{ booking_id_raw }}
                   {%- endif -%}
             - action: guesty.get_custom_field_values
+              metadata: {}
               data: >-
                 {{ dict(
                   target_type='reservation',
@@ -150,7 +151,7 @@ actions:
                   {%- set current_value =
                   current_fields.fields
                   | selectattr('field_id', 'equalto',
-                  custom_field_id)
+                  custom_field_id | string)
                   | map(attribute='value')
                   | first
                   | default(None) -%}

--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -138,12 +138,35 @@ actions:
                   {%- else -%}
                   {{ booking_id_raw }}
                   {%- endif -%}
-            - action: guesty.set_custom_field
-              metadata: {}
+            - action: guesty.get_custom_field_values
               data: >-
                 {{ dict(
                   target_type='reservation',
-                  target_id=reservation_id | string,
-                  field_id=custom_field_id,
-                  value=slot_code | string
+                  target_id=reservation_id | string
                 ) }}
+              response_variable: current_fields
+            - variables:
+                current_value: >-
+                  {%- set current_value =
+                  current_fields.fields
+                  | selectattr('field_id', 'equalto',
+                  custom_field_id)
+                  | map(attribute='value')
+                  | first
+                  | default(None) -%}
+                  {{ current_value }}
+            - if:
+                - condition: template
+                  value_template: >-
+                    {{ current_value | string
+                    != slot_code | string }}
+              then:
+                - action: guesty.set_custom_field
+                  metadata: {}
+                  data: >-
+                    {{ dict(
+                      target_type='reservation',
+                      target_id=reservation_id | string,
+                      field_id=custom_field_id,
+                      value=slot_code | string
+                    ) }}


### PR DESCRIPTION
Before calling `guesty.set_custom_field`, read the current value via `guesty.get_custom_field_values` and compare it to the `slot_code`. Skip the write when the values already match.

This avoids unnecessary API calls on every periodic sync and reduces Guesty API usage.