### PR TITLE
Fix(blueprints): Support both RC entity names

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -122,11 +122,9 @@ actions:
               sensor.{{ rc_device
               }}_rental_control_event_{{ event_index }}
             event_entity: >-
-              {% if has_value(event_entity_new) %}
-              {{ event_entity_new }}
-              {% else %}
-              {{ event_entity_old }}
-              {% endif %}
+              {{ event_entity_new
+              if has_value(event_entity_new)
+              else event_entity_old }}
         - if:
             - condition: template
               value_template: >-

--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -81,7 +81,9 @@ variables:
     {%- for i in range(max_events | int) -%}
       {%- set ns.entities = ns.entities +
       ['sensor.rental_control_' ~ rc_device
-      ~ '_event_' ~ i] -%}
+      ~ '_event_' ~ i,
+      'sensor.' ~ rc_device
+      ~ '_rental_control_event_' ~ i] -%}
     {%- endfor -%}
     {{ ns.entities }}
 
@@ -113,9 +115,18 @@ actions:
       sequence:
         - variables:
             event_index: "{{ repeat.index - 1 }}"
-            event_entity: >-
+            event_entity_old: >-
               sensor.rental_control_{{ rc_device
               }}_event_{{ event_index }}
+            event_entity_new: >-
+              sensor.{{ rc_device
+              }}_rental_control_event_{{ event_index }}
+            event_entity: >-
+              {% if has_value(event_entity_new) %}
+              {{ event_entity_new }}
+              {% else %}
+              {{ event_entity_old }}
+              {% endif %}
         - if:
             - condition: template
               value_template: >-

--- a/rental-control-hostaway-slot-code.yaml
+++ b/rental-control-hostaway-slot-code.yaml
@@ -89,7 +89,9 @@ variables:
     {%- for i in range(max_events | int) -%}
       {%- set ns.entities = ns.entities +
       ['sensor.rental_control_' ~ rc_device
-      ~ '_event_' ~ i] -%}
+      ~ '_event_' ~ i,
+      'sensor.' ~ rc_device
+      ~ '_rental_control_event_' ~ i] -%}
     {%- endfor -%}
     {{ ns.entities }}
   listing_id: >-
@@ -129,9 +131,18 @@ actions:
       sequence:
         - variables:
             event_index: "{{ repeat.index - 1 }}"
-            event_entity: >-
+            event_entity_old: >-
               sensor.rental_control_{{ rc_device
               }}_event_{{ event_index }}
+            event_entity_new: >-
+              sensor.{{ rc_device
+              }}_rental_control_event_{{ event_index }}
+            event_entity: >-
+              {% if has_value(event_entity_new) %}
+              {{ event_entity_new }}
+              {% else %}
+              {{ event_entity_old }}
+              {% endif %}
         - if:
             - condition: template
               value_template: >-

--- a/rental-control-hostaway-slot-code.yaml
+++ b/rental-control-hostaway-slot-code.yaml
@@ -138,11 +138,9 @@ actions:
               sensor.{{ rc_device
               }}_rental_control_event_{{ event_index }}
             event_entity: >-
-              {% if has_value(event_entity_new) %}
-              {{ event_entity_new }}
-              {% else %}
-              {{ event_entity_old }}
-              {% endif %}
+              {{ event_entity_new
+              if has_value(event_entity_new)
+              else event_entity_old }}
         - if:
             - condition: template
               value_template: >-


### PR DESCRIPTION
Home Assistant changed entity naming for Rental Control event sensors. Old installations use `sensor.rental_control_{name}_event_{n}` while new ones use `sensor.{name}_rental_control_event_{n}`.

## Changes
- Updated `rental-control-guesty-slot-code.yaml`: `rc_event_entities` now includes both naming patterns; action loop detects which pattern exists
- Updated `rental-control-hostaway-slot-code.yaml`: Same changes

## How it works
1. The `rc_event_entities` list now contains both old and new pattern entity IDs for trigger filtering
2. In the action loop, the automation checks for the new-style entity first (`has_value`), falls back to old-style
3. The existing `has_value(event_entity)` guard handles the case where neither exists