### PR TITLE
Chore: Bump blueprint versions to v0.2

### DIFF
--- a/rental-control-guesty-slot-code.yaml
+++ b/rental-control-guesty-slot-code.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 blueprint:
-  name: Rental Control Guesty Slot Code Sync (v0.1)
+  name: Rental Control Guesty Slot Code Sync (v0.2)
   description: |
     Syncs Rental Control slot codes to Guesty reservation custom
     fields. When Rental Control generates a slot_code for a guest

--- a/rental-control-hostaway-slot-code.yaml
+++ b/rental-control-hostaway-slot-code.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 blueprint:
-  name: Rental Control Hostaway Slot Code Sync (v0.1)
+  name: Rental Control Hostaway Slot Code Sync (v0.2)
   description: |
     Syncs Rental Control slot codes to Hostaway reservations. When
     Rental Control generates a slot_code for a guest, this automation


### PR DESCRIPTION
Bump version numbers in both slot code sync blueprints from v0.1 to v0.2 to reflect the entity naming compatibility changes and prior bug fixes.