### PR TITLE
Fix(thermostat): Use inline now() calls

### DIFF
--- a/thermostat-guest-manager.yaml
+++ b/thermostat-guest-manager.yaml
@@ -195,10 +195,10 @@ conditions:
 
 actions:
   - variables:
-      now_ts: "{{ now() }}"
       today_date: >-
         {{ as_local(now()).strftime('%Y-%m-%d') }}
       state_info: >-
+        {%- set now_ts = now() -%}
         {%- set ns = namespace(
           has_active=false,
           pre_arrival=false,


### PR DESCRIPTION
Fix `TypeError: '<=' not supported between instances of 'datetime.datetime' and 'str'` in the thermostat guest manager blueprint.

## Root cause
`now_ts: "{{ now() }}"` gets stringified by HA template rendering. When compared to actual datetime objects via `<=` and `<`, it throws a TypeError.

## Fix
Remove the `now_ts` variable and use `now()` directly in all comparisons within the `state_info` template. `now()` returns a proper datetime object when called inline within a Jinja2 block.