### PR TITLE
Chore(thermostat): Bump version to v0.2

### DIFF
--- a/thermostat-guest-manager.yaml
+++ b/thermostat-guest-manager.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 blueprint:
-  name: Thermostat Guest Schedule Manager (v0.1)
+  name: Thermostat Guest Schedule Manager (v0.2)
   description: |
     Manages thermostat settings based on Rental Control guest occupancy.
     Runs an energy-saving schedule between guests, pushes a target


### PR DESCRIPTION
Bump blueprint name version from v0.1 to v0.2 to reflect the datetime fix merged in PR #95.