### PR TITLE
Feat(lock): Add RC automatic door lock

### DIFF
--- a/rc-automatic-door-lock.yaml
+++ b/rc-automatic-door-lock.yaml
@@ -30,8 +30,8 @@ blueprint:
     wait_time:
       name: Lock Delay
       description: >-
-        Minutes to wait after the lock is unlocked before
-        automatically locking.
+        Minutes to wait before automatically locking. Applies
+        after a guest departs or the lock is unlocked.
       default: 5
       selector:
         number:
@@ -67,6 +67,9 @@ actions:
         sequence:
           - delay:
               minutes: !input wait_time
+          - condition: state
+            entity_id: !input rental_control_calendar
+            state: "off"
           - condition: state
             entity_id: !input lock
             state: unlocked

--- a/rc-automatic-door-lock.yaml
+++ b/rc-automatic-door-lock.yaml
@@ -1,0 +1,70 @@
+---
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+blueprint:
+  name: RC Automatic Door Lock (v0.1)
+  description: |
+    Automatically locks a door when no guest is present. When the
+    Rental Control calendar turns off (guest departs) or the lock
+    is unlocked while no guest is present, the door will be locked
+    after a configurable delay.
+
+  domain: automation
+
+  input:
+    rental_control_calendar:
+      name: Rental Control Calendar
+      description: >-
+        The calendar associated with the rental control device.
+      selector:
+        entity:
+          domain: calendar
+          integration: rental_control
+    lock:
+      name: Door Lock
+      description: >-
+        The lock to automatically secure between guests.
+      selector:
+        entity:
+          domain: lock
+    wait_time:
+      name: Lock Delay
+      description: >-
+        Minutes to wait after the lock is unlocked before
+        automatically locking.
+      default: 5
+      selector:
+        number:
+          min: 1
+          max: 60
+          unit_of_measurement: minutes
+          mode: box
+
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: !input rental_control_calendar
+    to: "off"
+    id: calendar_off
+  - trigger: state
+    entity_id: !input lock
+    to: unlocked
+    for:
+      minutes: !input wait_time
+    id: lock_unlocked
+
+conditions:
+  - condition: state
+    entity_id: !input rental_control_calendar
+    state: "off"
+  - condition: state
+    entity_id: !input lock
+    state: unlocked
+    for:
+      minutes: !input wait_time
+
+actions:
+  - action: lock.lock
+    target:
+      entity_id: !input lock

--- a/rc-automatic-door-lock.yaml
+++ b/rc-automatic-door-lock.yaml
@@ -58,13 +58,25 @@ conditions:
   - condition: state
     entity_id: !input rental_control_calendar
     state: "off"
-  - condition: state
-    entity_id: !input lock
-    state: unlocked
-    for:
-      minutes: !input wait_time
 
 actions:
-  - action: lock.lock
-    target:
-      entity_id: !input lock
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: calendar_off
+        sequence:
+          - delay:
+              minutes: !input wait_time
+          - condition: state
+            entity_id: !input lock
+            state: unlocked
+          - action: lock.lock
+            target:
+              entity_id: !input lock
+      - conditions:
+          - condition: trigger
+            id: lock_unlocked
+        sequence:
+          - action: lock.lock
+            target:
+              entity_id: !input lock

--- a/rc-automatic-door-lock.yaml
+++ b/rc-automatic-door-lock.yaml
@@ -45,6 +45,7 @@ mode: single
 triggers:
   - trigger: state
     entity_id: !input rental_control_calendar
+    from: "on"
     to: "off"
     id: calendar_off
   - trigger: state


### PR DESCRIPTION
## Summary

Adds a new blueprint that automatically locks a door when no guest
is present (RC calendar is off), with a configurable delay
(default 5 minutes).

## Triggers

- RC calendar event turning off (guest departure)
- Lock being unlocked while no guest is present

## Configuration

- **rental_control_calendar**: The RC guest calendar entity
- **lock**: The door lock entity to control
- **wait_time**: Minutes to wait before locking (default: 5)

## Behavior

When the RC calendar turns off or the lock is unlocked while the
calendar is already off, the blueprint waits the configured delay
then locks the door. This ensures the door is secured after guests
depart without requiring manual intervention.

For the `calendar_off` trigger, the delay is applied in the action
sequence with a post-delay state check to avoid locking if the
lock was manually locked during the wait. For the `lock_unlocked`
trigger, the delay is handled by the trigger's `for` clause.