### PR TITLE
Fix(hostaway-battery): Use hourly interval

### DIFF
--- a/hostaway-battery-task-creator.yaml
+++ b/hostaway-battery-task-creator.yaml
@@ -51,6 +51,8 @@ blueprint:
               value: "/30"
             - label: Every 59 minutes
               value: "/59"
+            - label: Every hour
+              value: "0"
     supervisor_user_id:
       name: Supervisor user ID
       description: >-

--- a/hostaway-battery-task-creator.yaml
+++ b/hostaway-battery-task-creator.yaml
@@ -49,8 +49,6 @@ blueprint:
               value: "/15"
             - label: Every 30 minutes
               value: "/30"
-            - label: Every 59 minutes
-              value: "/59"
             - label: Every hour
               value: "0"
     supervisor_user_id:

--- a/hostaway-battery-task-creator.yaml
+++ b/hostaway-battery-task-creator.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
 blueprint:
-  name: Hostaway Battery Task Creator (v0.7)
+  name: Hostaway Battery Task Creator (v0.8)
   description: >-
     Creates or updates Hostaway battery replacement tasks for low
     battery sensors and completes them after batteries recover.
@@ -49,8 +49,8 @@ blueprint:
               value: "/15"
             - label: Every 30 minutes
               value: "/30"
-            - label: Every 60 minutes
-              value: "/60"
+            - label: Every 59 minutes
+              value: "/59"
     supervisor_user_id:
       name: Supervisor user ID
       description: >-


### PR DESCRIPTION
Replace the invalid /60 minutes option with a valid hourly trigger using minute 0. This keeps the time_pattern selector valid and preserves an hourly schedule.